### PR TITLE
allow tagging private tracker only in modify task

### DIFF
--- a/qbittorrent_mod.py
+++ b/qbittorrent_mod.py
@@ -218,6 +218,7 @@ class PluginQBittorrentMod(QBittorrentModBase):
                         'type': 'object',
                         'properties': {
                             'tag_by_tracker': {'type': 'boolean'},
+                            'tag_single_tracker_only': {'type': 'boolean'},
                             'replace_trackers': {
                                 'type': 'object',
                                 'properties': {
@@ -641,15 +642,20 @@ class PluginQBittorrentMod(QBittorrentModBase):
     def modify_entries(self, task: Task, modify_options: dict) -> None:
         tag_by_tracker = modify_options.get('tag_by_tracker')
         replace_trackers = modify_options.get('replace_trackers')
+        tag_single_tracker_only = modify_options.get('tag_single_tracker_only')
         for entry in task.accepted:
             tags = entry.get('qbittorrent_tags')
             tags_modified = []
             torrent_trackers = entry.get('qbittorrent_trackers')
+            torrent_trackers_count = len(torrent_trackers)
             for tracker in torrent_trackers:
                 if tag_by_tracker:
-                    site_name = net_utils.get_site_name(tracker.get('url'))
-                    if site_name and site_name not in tags and site_name not in tags_modified:
-                        tags_modified.append(site_name)
+                    if tag_single_tracker_only and torrent_trackers_count!=1:
+                        pass
+                    else:
+                        site_name = net_utils.get_site_name(tracker.get('url'))
+                        if site_name and site_name not in tags and site_name not in tags_modified:
+                            tags_modified.append(site_name)
                 if replace_trackers:
                     for old_str, new_str in replace_trackers.items():
                         tracker_url = tracker.get('url')


### PR DESCRIPTION
因为我sonarr 里有public tracker rss indexer, 造成sonarr添加的种子会有一大堆tracker, 而原版modify task会把所有tracker url的名字提出来作为tag，结果就会出现一大堆不想要的tag, 有时我也会手动添加公开站点的种子，虽然可以配置sonarr 把所有他加的任务都放到sonarr category里，然后可以配置modify task忽略整个sonarr category, 可是我sonarr也有private tracker的indexer, 这样他们就不会被tag了

本来想假设只要在 msg里看到  `This torrent is private` 就可以认为他是 private tracker, 后来想想觉得也似乎没有必要，这样还可以少改个文件，少存点不是太有必要的信息

如果只有一个tracker，我就认为他是private tracker, 而且如果 tag_single_tracker_only，我就不tag他

![Screenshot from 2023-01-10 09-42-26](https://user-images.githubusercontent.com/2757572/211643660-6c0afb9a-4d42-45df-83c5-2f243be358d4.png)
